### PR TITLE
Bug fix for trying to load bad data using fom library: Encountered on lo...

### DIFF
--- a/load_article.py
+++ b/load_article.py
@@ -82,7 +82,11 @@ def load_article_into_fi(a = None):
 					 or k == "authors" or k == "refs" or k == "components" or k == "fim"):
 			#print k
 			if(v != None):
-				setattr(obj, k, v)
+				try:
+					setattr(obj, k, v)
+				except ValueError:
+					# Gracefully recover from "ValueError: Cannot lazy-save a non-primitive value."
+					pass
 				
 	print obj.doi_url
 


### PR DESCRIPTION
...ading keywords for article 01730

File "/usr/local/lib/python2.7/dist-packages/fom/mapping.py", line 438, in set_lazy_tag_value
    raise ValueError('Cannot lazy-save a non-primitive value.')
ValueError: Cannot lazy-save a non-primitive value.
